### PR TITLE
Deprecate bublejs-brunch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-[![npm][npm-image]][npm-url]
-[![License][license-image]][license-url]
+> ## 🚧 This Plugin Is Depreacted 🚧
+
+> This plugin is deprecated in favor of [buble-brunch](https://github.com/roperzh/buble-brunch).
 
 # bublejs-brunch
+
+[![npm][npm-image]][npm-url]
+[![License][license-image]][license-url]
 
 Adds support to [Brunch](http://brunch.io) to transform ES6 into ES5 with [Bublé](https://buble.surge.sh).
 


### PR DESCRIPTION
This PR adds a deprecation message for users. Please, do not deprecate this plugin on NPM. Let's do not disturb them with useless warnings in logs.

---

Depends on https://github.com/roperzh/buble-brunch/pull/4